### PR TITLE
VLSR

### DIFF
--- a/virgo/virgo.py
+++ b/virgo/virgo.py
@@ -701,9 +701,6 @@ def plot(obs_parameters='', n=0, m=0, f_rest=0, slope_correction=False, dB=False
 		from astropy.coordinates import SpectralCoord, EarthLocation, SkyCoord
 		from astropy.time import Time
 
-		# Adjust for wrong time on Raspberry Pi
-		mjd += .38125
-
 		obs_location = EarthLocation.from_geodetic(loc[0], loc[1], loc[2])
 		obs_time = obs_location.get_itrs(obstime=Time(str(mjd), format='mjd', scale='utc'))
 

--- a/virgo/virgo.py
+++ b/virgo/virgo.py
@@ -600,8 +600,8 @@ def plot(obs_parameters='', n=0, m=0, f_rest=0, slope_correction=False, dB=False
 		f_rest: float. Spectral line reference frequency used for radial velocity (Doppler shift) calculations [Hz]
 		slope_correction: bool. Correct slope in poorly-calibrated spectra using linear regression
 		dB: bool. Display data in decibel scaling
-		vslr: bool. Display graph in VSLR frame of reference
-		rfi: list. Blank frequency channels contaminated with RFI ([low_frequency, high_frequency]) [Hz]
+		vlsr: bool. Display graph in VLSR frame of reference
+		rfi: list of tuples. Blank frequency channels contaminated with RFI ([(low_frequency, high_frequency), ...]) [Hz]
 		cal_ylim: list. Calibrated plot y-axis limits ([low, high])
 		xlim: list. x-axis limits ([low_frequency, high_frequency]) [Hz]
 		ylim: list. y-axis limits ([start_time, end_time]) [Hz]
@@ -944,7 +944,7 @@ def plot(obs_parameters='', n=0, m=0, f_rest=0, slope_correction=False, dB=False
 		ax2.set_ylabel('Signal-to-Noise Ratio (S/N)')
 
 		if vlsr:
-			cal_title = 'Calibrated Spectrum (VSLR)\n'
+			cal_title = r'$Calibrated Spectrum (V_{LSR})$' + '\n'
 		else:
 			cal_title = 'Calibrated Spectrum\n'
 


### PR DESCRIPTION
I've added the ability to adjust for VLSR in the calibrated plot. I haven't gone through and updated the docs or the version number yet. I wanted to give you a chance to look the code over and perhaps test it first.

To place the reading in the VLSR reference frame, the program needs to know three pieces of information: the observer's location (in longitude, latitude, and elevation), the target of the observation, and the time of the observation. Time is already recorded in the header files, but the others needed to be added. They are passed into the observe() function as obs_parameters.

For the target, two options are available for representing the target coordinates. The coordinates can be given in ra/dec, which will work best for single observations or tracked observations. The coordinates can also be given in alt/az. This allows the telescope to perform drift scans. Since the program knows the observer's location and the time, it can convert the alt/az for each reading into ra/dec.

If someone passes in both ra/dec and alt/az as parameters, the program will use alt/az.

To perform a plot in VLSR, the parameter vlsr=True should be passed with the plot. The default is vlsr=False. I have updated the title of the calibrated plot so it indicates when the plot is in VLSR.

I've also added a way for users to control the limits of the y-axis on the calibrated plot. Passing in cal_ylim=[N1,N2] will set the lower limit to N1 and the upper limit to N2. If no parameter or cal_ylim=[0,0] is passed, the program will choose the appropriate  limits on the basis of the data.

Let me know if this is a direction you would like to go.

Will resolve #18 and #16.