### PR TITLE
Added plt.close() function to min memory usage

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -20,6 +20,8 @@ simulate
    :type v_min: float
    :param v_max: Maximum radial velocity (xlim) [km/s]
    :type v_max: float
+   :param plot_file: Output plot filename
+   :type plot_file: string
 
    Output: *NoneType*
 
@@ -36,8 +38,10 @@ predict
    :type lon: float
    :param height: Observer elevation [m]
    :type height: float
-   :param source: Date in YYYY-MM-DD format. If no date is given, it defaults to today's system date.
+   :param source: Source object name to predict.
    :type source: string
+   :param date: Date in YYYY-MM-DD format. If no date is given, it defaults to today's system date.
+   :type date: string
    :param plot_sun: Also plot Sun position for reference
    :type plot_sun: bool
    :param plot_file: Output plot filename

--- a/virgo/virgo.py
+++ b/virgo/virgo.py
@@ -207,6 +207,7 @@ def predict(lat, lon, height=0, source='', date='', plot_sun=True, plot_file='')
 	else:
 		plt.show()
 	plt.clf()
+	plt.close()
 
 def equatorial(alt, az, lat, lon, height=0):
 	'''
@@ -484,6 +485,7 @@ def map_hi(ra=None, dec=None, plot_file=''):
 		plt.tight_layout()
 		plt.show()
 	plt.clf()
+	plt.close()
 
 def observe(obs_parameters, spectrometer='wola', obs_file='observation.dat', start_in=0):
 	'''
@@ -1066,6 +1068,7 @@ def plot(obs_parameters='', n=0, m=0, f_rest=0, slope_correction=False, dB=False
 	plt.tight_layout()
 	plt.savefig(plot_file)
 	plt.clf()
+	plt.close()
 
 def plot_rfi(rfi_parameters, data='rfi_data', dB=True, plot_file='plot.png'):
 	'''
@@ -1164,6 +1167,7 @@ xycoords='axes points', size=32, ha='left', va='top', color='brown')
 	plt.tight_layout()
 	plt.savefig(plot_file)
 	plt.clf()
+	plt.close()
 
 def monitor_rfi(f_lo, f_hi, obs_parameters, data='rfi_data'):
 	'''


### PR DESCRIPTION
1/ Couple of small Doc updates to the Predict reference documentation
2 Added plt.close() function to free up used memory after each plot has been saved.

See following for further detail.
https://stackoverflow.com/questions/7101404/how-can-i-release-memory-after-creating-matplotlib-figures
https://gist.github.com/astrofrog/824941

https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.clf.html
https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.close.html